### PR TITLE
Add Cargo build script for Metal shader compilation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,7 +17,7 @@ fn main() {
     }
 
     let status = Command::new("xcrun")
-        .args(["-sdk", "macosx", "metalib", air_path, "-o", metallib_path])
+        .args(["-sdk", "macosx", "metallib", air_path, "-o", metallib_path])
         .status()
         .expect("Failed to link metallib");
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,27 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=src/shaders/normals.metal");
+
+    let shader_path = "src/shaders/normals.metal";
+    let air_path = "src/shaders/normals.air";
+    let metallib_path = "src/shaders/normals.metallib";
+
+    let status = Command::new("xcrun")
+        .args(["-sdk", "macosx", "metal", "-c", shader_path, "-o", air_path])
+        .status()
+        .expect("Failed to compile shader to AIR");
+
+    if !status.success() {
+        panic!("Shader compilation failed");
+    }
+
+    let status = Command::new("xcrun")
+        .args(["-sdk", "macosx", "metalib", air_path, "-o", metallib_path])
+        .status()
+        .expect("Failed to link metallib");
+
+    if !status.success() {
+        panic!("Metallib linking failed");
+    }
+}


### PR DESCRIPTION
## Summary
- Add Cargo build.rs script to automatically compile Metal shaders during build
- Shaders in `src/shaders/` are now compiled automatically via `xcrun` when changed

## Test plan
- Build the project and verify shaders compile automatically
- Modify a shader file and verify it recompiles on next build

🤖 Generated with [Claude Code](https://claude.com/claude-code)